### PR TITLE
Handle rare edge case exception in boot.py

### DIFF
--- a/python/boot.py
+++ b/python/boot.py
@@ -9,8 +9,8 @@ r=machine.RTC()
 # Restore clock save or set sane default value if no save
 try:
     with open("hwclock.save","rb") as fr: r.datetime(unpack("<8I",fr.read()))
-except OSError as e:
-    r.datetime((2023, 1, 29, 6, 13, 55, 0, 0))
+except (OSError,ValueError) as e:
+    r.datetime((2023, 2, 9, 4, 13, 59, 0, 0))
 
 # function to save the RTC 
 def rtSaverCallback(t):


### PR DESCRIPTION
In the rare case where power cycle or power loss happens when the rtc saver function is writing the RTC data to the storage, the partially written data cannot be used to set the RTC on the next startup. This triggers a ValueError by `ustruct.unpack()` . This MR adds that to the exception list to be handled for setting a sane default. 